### PR TITLE
Fix: Remove Misconfigured Logs and Metrics

### DIFF
--- a/byoa.yaml
+++ b/byoa.yaml
@@ -13,16 +13,7 @@ x-omnistrate-integrations:
 
 x-internal-integrations:
   metrics:
-    provider: datadog
-    endpoint: us5.datadoghq.com
-    secretLocators:
-      aws: arn:aws:secretsmanager:us-east-1:541226919566:secret:demo/integration/datadog-GoTe4I
-
   logs:
-    provider: datadog
-    endpoint: us5.datadoghq.com
-    secretLocators:
-      aws: arn:aws:secretsmanager:us-east-1:541226919566:secret:demo/integration/datadog-GoTe4I
 
 name: supabase
 services:

--- a/pro-network.yaml
+++ b/pro-network.yaml
@@ -1,6 +1,6 @@
 version: "3.9"
 x-omnistrate-service-plan:
-  name: 'Enterprise Tier'
+  name: 'Premium Tier'
   tenancyType: 'OMNISTRATE_DEDICATED_TENANCY'
   deployment:
     hostedDeployment:


### PR DESCRIPTION
Removed Logs and Metrics configured using Datadog on the BYOA plan.

**Note: These changes were not released to the service. Changes were made to the Repo and pushing a fix for it.**